### PR TITLE
Fix #43 Roomless devices not showing up in device registry

### DIFF
--- a/custom_components/onesmartcontrol/manifest.json
+++ b/custom_components/onesmartcontrol/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "onesmartcontrol",
   "name": "One Smart Control",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "config_flow": true,
   "integration_type": "hub",
   "documentation": "https://github.com/PimDoos/onesmartcontrolha",

--- a/custom_components/onesmartcontrol/manifest.json
+++ b/custom_components/onesmartcontrol/manifest.json
@@ -3,6 +3,7 @@
   "name": "One Smart Control",
   "version": "0.3.1",
   "config_flow": true,
+  "integration_type": "hub",
   "documentation": "https://github.com/PimDoos/onesmartcontrolha",
   "issue_tracker": "https://github.com/PimDoos/onesmartcontrolha/issues",
   "requirements": [],

--- a/custom_components/onesmartcontrol/onesmartentity.py
+++ b/custom_components/onesmartcontrol/onesmartentity.py
@@ -91,7 +91,10 @@ class OneSmartEntity(Entity):
             identifiers = {(DOMAIN, self._device_id)}
             device_name = self._device.get(OneSmartFieldName.NAME, None)
             model = self._device.get(OneSmartFieldName.TYPE, None)
-            room_name = self._room.get(OneSmartFieldName.NAME, None)
+            if self._room:
+                room_name = self._room.get(OneSmartFieldName.NAME, None)
+            else:
+                room_name = None
 
         return {
             ATTR_IDENTIFIERS: identifiers,


### PR DESCRIPTION
Fixes a regression from v0.3.0, which adds room hints to devices. Devices not assigned to a room got a NoneTypeException and did not show up in the device registry.