### PR TITLE
Set power meters to 0 before update

### DIFF
--- a/custom_components/onesmartcontrol/manifest.json
+++ b/custom_components/onesmartcontrol/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PimDoos/onesmartcontrolha/issues",
   "requirements": [],
-  "version": "0.3.8"
+  "version": "0.4.0"
 }

--- a/custom_components/onesmartcontrol/onesmartwrapper.py
+++ b/custom_components/onesmartcontrol/onesmartwrapper.py
@@ -270,9 +270,15 @@ class OneSmartWrapper():
                     # Handle events
                     for event in events:
                         if event[OneSmartFieldName.EVENT] == OneSmartEventType.ENERGY_CONSUMPTION and len(self.cache[(OneSmartCommand.METER,OneSmartAction.LIST)]) > 0:
+                            # Set all meters to 0 in case no value is received
+                            for meter in self.cache[(OneSmartCommand.METER,OneSmartAction.LIST)]:
+                                self.cache[OneSmartEventType.ENERGY_CONSUMPTION][meter[OneSmartFieldName.ID]] = 0
+
+                            # Update meters from energy consumption event
                             for reading in event[OneSmartFieldName.DATA][OneSmartFieldName.VALUES]:
                                 meter_value = reading["value"]
-                                self.cache[OneSmartEventType.ENERGY_CONSUMPTION][reading["id"]] = meter_value
+                                self.cache[OneSmartEventType.ENERGY_CONSUMPTION][reading[OneSmartFieldName.ID]] = meter_value
+
                         elif event[OneSmartFieldName.EVENT] == OneSmartEventType.SITE_UPDATE:
                             self.cache[OneSmartEventType.SITE_UPDATE] = event[OneSmartFieldName.DATA]
                         elif event[OneSmartFieldName.EVENT] == OneSmartEventType.PRESET_PERFORM:


### PR DESCRIPTION
Power meters would remain unavailable or outdated when the measured power is 0, as One Smart Control would not update the value if it is 0.
Now setting every meter to 0 before handling the update event.