### PR TITLE
Fix #64 typo in flow rate units

### DIFF
--- a/custom_components/onesmartcontrol/manifest.json
+++ b/custom_components/onesmartcontrol/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PimDoos/onesmartcontrolha/issues",
   "requirements": [],
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/custom_components/onesmartcontrol/onesmartwrapper.py
+++ b/custom_components/onesmartcontrol/onesmartwrapper.py
@@ -604,7 +604,7 @@ class OneSmartWrapper():
                                 use_entity = True
                             
                             elif "flow_rate_4graph" in attribute_name:
-                                entity[ATTR_UNIT_OF_MEASUREMENT] = f"{UnitOfVolume.LITER}/{UnitOfTime.MINUTE}"
+                                entity[ATTR_UNIT_OF_MEASUREMENT] = f"{UnitOfVolume.LITERS}/{UnitOfTime.MINUTES}"
                                 use_entity = True
                               
                             elif "_power" in attribute_name:


### PR DESCRIPTION
Used 'LITER/MINUTE' where it should have been 'LITERS/MINUTES'