### PR TITLE
Fix deprecation message around light entities + Fix security system errors when using HA Homekit integration

### DIFF
--- a/custom_components/onesmartcontrol/alarm_control_panel.py
+++ b/custom_components/onesmartcontrol/alarm_control_panel.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 
 from homeassistant.const import (
     STATE_ALARM_DISARMED,
+    STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_NIGHT
 )
@@ -84,13 +85,13 @@ class OneSmartAlarmPanel(OneSmartEntity, AlarmControlPanelEntity):
 
     @property
     def supported_features(self) -> AlarmControlPanelEntityFeature:
-        return AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT
+        return AlarmControlPanelEntityFeature.ARM_HOME | AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT
 
     @property
     def state(self):
         onesmartvalue = self.get_cache_value(self._key)
         if onesmartvalue == OneSmartDefaultSitePreset.HOME:
-            return STATE_ALARM_DISARMED
+            return STATE_ALARM_ARMED_HOME
         if onesmartvalue == OneSmartDefaultSitePreset.AWAY:
             return STATE_ALARM_ARMED_AWAY
         if onesmartvalue == OneSmartDefaultSitePreset.ASLEEP:

--- a/custom_components/onesmartcontrol/light.py
+++ b/custom_components/onesmartcontrol/light.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON, SERVICE_TURN_OFF, STATE_OFF
 )
 from homeassistant.components.light import (
-    LightEntity, LightEntityDescription, ColorMode, ATTR_BRIGHTNESS, ATTR_SUPPORTED_COLOR_MODES
+    LightEntity, LightEntityDescription, ColorMode, ATTR_BRIGHTNESS, ATTR_SUPPORTED_COLOR_MODES, ATTR_COLOR_MODE
 )
 from homeassistant.core import HomeAssistant
 
@@ -80,10 +80,10 @@ class OneSmartLight(OneSmartEntity, LightEntity):
         
         if color_modes == None:
             self._attr_supported_color_modes = [ColorMode.ONOFF]
+            self._attr_color_mode = ColorMode.ONOFF
         else:
-            self._attr_supported_color_modes = color_modes
-
-        
+            self._attr_supported_color_modes = color_modes       
+            self._attr_color_mode = color_modes[0]
 
         self._command_on = command_on
         self._command_off = command_off


### PR DESCRIPTION
Light entity:
Link to details around the mentioned deprecation message:
https://developers.home-assistant.io/blog/2024/02/12/light-color-mode-mandatory/

Alarm Control Panel entity:
HA was throwing the following error messages when using the Homekit integration:
```
SecuritySystemCurrentState: value=0 is an invalid value.
SecuritySystemTargetState: value=0 is an invalid value.
```
Homekit apparently expects the ARMED_HOME mode to be there, so using that instead of the DISARMED mode.