### PR TITLE
Update alarm_control_panel.py for Home Assistant 2024.8+ compatibility

### DIFF
--- a/custom_components/onesmartcontrol/alarm_control_panel.py
+++ b/custom_components/onesmartcontrol/alarm_control_panel.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 from homeassistant.config_entries import ConfigEntry
 
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+
 from homeassistant.components.alarm_control_panel import (
-    AlarmControlPanelEntity, AlarmControlPanelEntityFeature, AlarmControlPanelState
+    AlarmControlPanelEntity, AlarmControlPanelEntityFeature
 )
 from homeassistant.core import HomeAssistant
 
@@ -81,12 +83,12 @@ class OneSmartAlarmPanel(OneSmartEntity, AlarmControlPanelEntity):
         return AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT
 
     @property
-    def alarm_state(self):
+    def state(self):
         onesmartvalue = self.get_cache_value(self._key)
         if onesmartvalue == OneSmartDefaultSitePreset.HOME:
             return AlarmControlPanelState.DISARMED
         if onesmartvalue == OneSmartDefaultSitePreset.AWAY:
-            return AlarmControlPanelState.ARMED_AWAY
+            return AlarmControlPanelState.AWAY
         if onesmartvalue == OneSmartDefaultSitePreset.ASLEEP:
             return AlarmControlPanelState.ARMED_NIGHT
         return None


### PR DESCRIPTION
This PR updates the alarm_control_panel.py file of the One Smart Control custom component to restore compatibility with newer Home Assistant versions (2024.8 and above).

In recent Home Assistant releases, the legacy constants such as
STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY, etc.
were removed from both homeassistant.const and
homeassistant.components.alarm_control_panel.const.

They have been replaced by the new AlarmControlPanelState enum.

See: https://developers.home-assistant.io/blog/2024/10/22/new-alarm-state-property/


Tested locally on Home Assistant 2025.11.0